### PR TITLE
Fix: Theme provider - User pref persistency 

### DIFF
--- a/src/providers/localization/localizationProvider.tsx
+++ b/src/providers/localization/localizationProvider.tsx
@@ -17,7 +17,7 @@ export const LocalizationContext = React.createContext<ILocalizationContext>({
 });
 
 export const LocalizationProvider: React.FC<IProps> = ({ customLocales, children }) => {
-  const [loaded, setLoaded] = useState(false);
+  const [localesLoaded, setLocalesLoaded] = useState(false);
 
   const [availableLocales, setAvailableLocales] = useState<
     Record<string, Partial<ILocalizedStrings>>
@@ -56,7 +56,7 @@ Available locales: ${Object.keys(availableLocales).join(', ')}`);
 
   useEffect(() => {
     if (!customLocales || Object.keys(customLocales).length === 0) {
-      return setLoaded(true);
+      return setLocalesLoaded(true);
     }
 
     const filledCustomLocales: Record<string, ILocalizedStrings> = {};
@@ -71,11 +71,11 @@ Available locales: ${Object.keys(availableLocales).join(', ')}`);
     setAvailableLocales((prevState) => {
       return { ...prevState, ...filledCustomLocales };
     });
-    setLoaded(true);
+    setLocalesLoaded(true);
   }, [customLocales]);
 
   useEffect(() => {
-    if (!loaded) return;
+    if (!localesLoaded) return;
 
     let warn = true;
     let locale = localStorage.getItem(LOCAL_STORAGE_KEY);
@@ -89,7 +89,7 @@ Available locales: ${Object.keys(availableLocales).join(', ')}`);
     /* istanbul ignore next */
     setViableLocaleOrDefault(locale ?? defaultLocale, warn);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded]);
+  }, [localesLoaded]);
 
   const switchTo = (nextLocale: LocaleType) => {
     const [name] = setViableLocaleOrDefault(nextLocale);

--- a/src/providers/theme/themeProvider.tsx
+++ b/src/providers/theme/themeProvider.tsx
@@ -23,6 +23,7 @@ export const ThemeContext = React.createContext<IThemeContext>({
 });
 
 export const ThemeProvider: React.FC<IProps> = ({ customThemes, children }) => {
+  const [themesLoaded, setThemesLoaded] = useState(false);
   const [availableThemes, setAvailableThemes] = useState<Record<string, ITheme>>(defaultThemes);
   const [currentTheme, setCurrentTheme] = useState<IViableTheme>(defaultTheme);
 
@@ -52,13 +53,9 @@ Available themes: ${Object.keys(availableThemes).join(', ')}`);
   );
 
   useEffect(() => {
-    const theme = localStorage.getItem(LOCAL_STORAGE_KEY) ?? 'light';
-    setViableThemeOrDefault(theme);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (!customThemes || Object.keys(customThemes).length === 0) return;
+    if (!customThemes || Object.keys(customThemes).length === 0) {
+      return setThemesLoaded(true);
+    }
     const filledCustomThemes: Record<string, ITheme> = {};
 
     Object.keys(customThemes).forEach((key) => {
@@ -69,7 +66,17 @@ Available themes: ${Object.keys(availableThemes).join(', ')}`);
     setAvailableThemes((prevState) => {
       return { ...prevState, ...filledCustomThemes };
     });
+
+    setThemesLoaded(true);
   }, [customThemes]);
+
+  useEffect(() => {
+    if (!themesLoaded) return;
+
+    const theme = localStorage.getItem(LOCAL_STORAGE_KEY) ?? 'light';
+    setViableThemeOrDefault(theme);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [themesLoaded]);
 
   const switchTo = (nextTheme: ThemeLabel | string) => {
     const [name] = setViableThemeOrDefault(nextTheme);


### PR DESCRIPTION
**Fixes the following issue:**
- Requested custom theme is not persisted when reloading the page.

**Steps to reproduce:**

1.  Select a custom theme [here](https://paulfasola.github.io/adoption/?path=/story/localizationprovider--custom-locales)
2.  Reload the page
3. Theme is defaulted to light instead of the selected theme